### PR TITLE
initialize editors with value of associated hidden input

### DIFF
--- a/templates/Words/add.php
+++ b/templates/Words/add.php
@@ -103,7 +103,7 @@
 //                          echo $this->Form->control('sentences.' . $i . '.sentence', ['label' => 'Example Sentence(s)', 'class' => 'muliplespsp', 'size' => '60']);
                             echo $this->Form->hidden('sentences.' . $i . '.sentence', ['id' => 'sentences' . $i]);
                             echo "<label>Example Sentence(s)</label>";
-                            echo "<div class='editor-container'><div id='editor-sentences' . $i'></div></div>";
+                            echo "<div class='editor-container'><div id='editor-sentences$i'></div></div>";
                             echo "<a class='add-editor'><i class='icon-plus-sign'></i> Add an additional sentence</a>&nbsp;&nbsp;";
 				                    echo "<a class='remove-editor disabled'><i class='icon-minus-sign'></i> Remove</a>";
                             echo "</div>";

--- a/webroot/js/addform.js
+++ b/webroot/js/addform.js
@@ -85,14 +85,7 @@ $(function()
 		$(this).hide();
 	});
 
-	var editors = $('[id^=editor]');
-	var mappedEditors = [];
-	editors.each((index, el) => {
-		  var quill = new Quill(el, {
-			  theme: 'snow'
-		  });
-		  mappedEditors.push({"id": $(el).attr('id').replace('editor-', ''), "editor": quill});
-	});
+	var mappedEditors = initializeEditors();
   
 	$('#add_form').submit(function(e) {
 		mappedEditors.forEach((el) => {
@@ -114,6 +107,29 @@ function setConfirmUnload(on)
 function unloadMessage()
 {
 	return 'The data you entered will be lost.';
+}
+
+function initializeEditors() {
+	var editors = $('[id^=editor]');
+	var mappedEditors = [];
+	editors.each((index, el) => {
+		  var quill = new Quill(el, {
+			  theme: 'snow'
+		  });
+		  mappedEditors.push({"id": $(el).attr('id').replace('editor-', ''), "editor": quill});
+	});
+	setInitialValues(mappedEditors);
+	return mappedEditors;
+}
+
+function setInitialValues(mappedEditors) {
+	mappedEditors.forEach(editor => {
+		const hiddenContent = $('#' + editor.id).val();
+		if (hiddenContent) {
+			var content = JSON.parse(hiddenContent);
+			editor.editor.setContents(content.ops);
+		}
+	});
 }
 
 function updateAttribute(el, attribute, counter, nextCounter) {
@@ -176,6 +192,7 @@ function addEditorField(el, mappedEditors) {
 	var quill = new Quill(editorClone[0], {
 		theme: 'snow'
 	});
+	quill.setContents([]);
 	mappedEditors.push({"id": $(editorClone).attr('id').replace('editor-', ''), "editor": quill});
 	quill.focus();
 }


### PR DESCRIPTION
@joshv2  I updated the code so that if the associated hidden input has a value, it will use that value to initialize the value of the editor. This should work in both cases of edit and error/post cases.
