### PR TITLE
ensure recording is fully saved when user clicks save in dialog witho…

### DIFF
--- a/webroot/js/recorder.js
+++ b/webroot/js/recorder.js
@@ -66,9 +66,11 @@
           }
           exConfirmPromise.make(configOpt).then((option) => {
             theStream.getTracks().forEach(track => track.stop());
-            if (option) {
-                callback(theBlob);
-            }
+            setTimeout(() => {
+                if (option) {
+                    callback(theBlob);
+                }
+            }, 10);
           });
           var dialogContents = document.getElementById('dialogContents');
           dialogContents.appendChild(recorderUI);


### PR DESCRIPTION
This should fix the issue when user clicks "save" in dialog without first stopping the recorder. The full file will now be saved/part of the form.
